### PR TITLE
Don't lose pending jobs in case of unclean exit

### DIFF
--- a/src/win_main.cpp
+++ b/src/win_main.cpp
@@ -479,6 +479,7 @@ void MainWindow::deleteButtonPressed(void)
 	ENSURE_APP_IS_READY();
 
 	m_jobList->deleteJob(ui->jobsView->currentIndex());
+	m_jobList->saveQueuedJobs();
 	m_label[0]->setVisible(m_jobList->rowCount(QModelIndex()) == 0);
 }
 
@@ -1596,6 +1597,7 @@ bool MainWindow::appendJob(const QString &sourceFileName, const QString &outputF
 	bool okay = false;
 	EncodeThread *thrd = new EncodeThread(sourceFileName, outputFileName, options, m_sysinfo.data(), m_preferences.data());
 	QModelIndex newIndex = m_jobList->insertJob(thrd);
+	m_jobList->saveQueuedJobs();
 
 	if(newIndex.isValid())
 	{

--- a/src/win_main.cpp
+++ b/src/win_main.cpp
@@ -1120,7 +1120,6 @@ void MainWindow::init(void)
 	if(m_jobList->loadQueuedJobs(m_sysinfo.data()) > 0)
 	{
 		m_label[0]->setVisible(m_jobList->rowCount(QModelIndex()) == 0);
-		m_jobList->clearQueuedJobs();
 	}
 }
 
@@ -1413,6 +1412,10 @@ void MainWindow::closeEvent(QCloseEvent *e)
 					PreferencesModel::savePreferences(m_preferences.data());
 				}
 				m_jobList->saveQueuedJobs();
+			}
+			else
+			{
+				m_jobList->clearQueuedJobs();
 			}
 		}
 		else


### PR DESCRIPTION
Ensure all pending jobs are retained in case the application is not closed cleanly for any reason:

- Clear job queue file only at exit, and only if the user chooses not to save the queue.
- Immediately save the queue to file when a job is added or removed, to prevent the changes from being lost in case of unclean exit. Queue file will still be cleared if user chooses to do so when closing the application.